### PR TITLE
Add extra_host needed for compose up on MacOS

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -160,6 +160,7 @@ services:
     extra_hosts:
       docker.for.lin.host.internal: 172.16.238.1
       docker.for.lin.localhost: 172.16.238.1
+      host.docker.internal: host-gateway
 
     networks:
       app_net:


### PR DESCRIPTION
When using `docker compose up` you need to define `host.docker.internal` under `extra_hosts` for the container to have access. This should be cross-platform compatible as of Docker 20.10.